### PR TITLE
add Ord instance

### DIFF
--- a/src/Node/UUID.purs
+++ b/src/Node/UUID.purs
@@ -9,7 +9,7 @@ module Node.UUID where
   import Data.Foreign (readString)
   import Data.Foreign.Class (IsForeign)
 
-  import Prelude (Eq, Show, (#), ($), (==), (<$>), (>>>), (>>=), show)
+  import Prelude (Ord, Eq, Show, (#), ($), (==), (<$>), (>>>), (>>=), show, compare)
 
   foreign import data UUID :: *
   foreign import data UUIDEff :: !
@@ -26,6 +26,9 @@ module Node.UUID where
 
   instance eqUUID :: Eq UUID where
     eq ident ident' = showuuid ident == showuuid ident'
+
+  instance ordUUID :: Ord UUID where
+    compare ident ident' = compare (showuuid ident) (showuuid ident')
 
   instance showUUID :: Show UUID where
     show ident = showuuid ident


### PR DESCRIPTION
I'm pretty new to all of this, but I was trying to use this as the key of a map and noticed it didn't have an Ord instance, so I added one for my purposes, thought I'd see if you were interested in it. Not being from a web background the whole comparing strings things for equality/ord seems odd to me, but I guess in JS everything is sort of a string anyway so it's not so bad?
